### PR TITLE
Upstream sync - b3566cd

### DIFF
--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -31,6 +31,9 @@ service ETHBACKEND {
 
   rpc EngineGetPayloadBodiesByRangeV1(EngineGetPayloadBodiesByRangeV1Request) returns (EngineGetPayloadBodiesV1Response);
 
+  // Fetch the blobs bundle using its ID.
+  rpc EngineGetBlobsBundleV1(EngineGetBlobsBundleRequest) returns (types.BlobsBundleV1);
+
   // End of Engine API requests
   // ------------------------------------------------------------------------
 
@@ -90,6 +93,10 @@ message NetPeerCountReply { uint64 count = 1; }
 
 
 message EngineGetPayloadRequest {
+  uint64 payloadId = 1;
+}
+
+message EngineGetBlobsBundleRequest {
   uint64 payloadId = 1;
 }
 

--- a/remote/kv.proto
+++ b/remote/kv.proto
@@ -157,7 +157,8 @@ message SnapshotsRequest {
 }
 
 message SnapshotsReply {
-  repeated string files = 1;
+  repeated string blocks_files = 1;
+  repeated string history_files = 2;
 }
 
 message RangeReq  {
@@ -241,10 +242,10 @@ message Pairs {
 }
 
 message ParisPagination {
-  bytes NextKey = 1;
-  sint64 Limit = 2;
+  bytes next_key = 1;
+  sint64 limit = 2;
 }
 message IndexPagination {
-  sint64 NextTimeStamp = 1;
-  sint64 Limit = 2;
+  sint64 next_time_stamp = 1;
+  sint64 limit = 2;
 }

--- a/types/types.proto
+++ b/types/types.proto
@@ -59,7 +59,7 @@ message VersionReply {
 // Engine API types
 // See https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md
 message ExecutionPayload {
-  uint32 version = 1; // v1 - no withdrawals, v2 - with withdrawals
+  uint32 version = 1; // v1 - no withdrawals, v2 - with withdrawals, v3 - with excess data gas
   H256 parentHash = 2;
   H160 coinbase = 3;
   H256 stateRoot = 4;
@@ -75,6 +75,7 @@ message ExecutionPayload {
   H256 blockHash = 14;
   repeated bytes transactions = 15;
   repeated Withdrawal withdrawals = 16;
+  H256 excessDataGas = 17;
 }
 
 message Withdrawal {
@@ -83,6 +84,15 @@ message Withdrawal {
   H160 address = 3;
   uint64 amount = 4;
 }
+
+message BlobsBundleV1 {
+  H256 blockHash = 1;
+  // TODO(eip-4844): define a protobuf message for type KZGCommitment
+  repeated bytes kzgs = 2;
+  // TODO(eip-4844): define a protobuf message for type Blob
+  repeated bytes blobs = 3;
+}
+
 // End of Engine API types
 // ------------------------------------------------------------------------
 


### PR DESCRIPTION
## Upstream sync PR

### erigon
`ledgerwatch/erigon` [v2.39.0](https://github.com/ledgerwatch/erigon/releases/tag/v2.39.0) -> `testinprod-io/op-erigon` [v2.38.1-0.1.1](https://github.com/testinprod-io/op-erigon/releases/tag/v2.38.1-0.1.1), 

### erigon-lib
`ledgerwatch/erigon-lib` [6b3b7ab](https://github.com/ledgerwatch/erigon-lib/commit/6b3b7ab434b7910f0c5fa9347f90410595822f18) -> `testinprod-io/erigon-lib` [7e2584b](https://github.com/testinprod-io/erigon-lib/commit/7e2584b1f5661c0d1c11bbcb24bfc87c7d218a02)

### erigon-interfaces
`ledgerwatch/interfaces` [b3566cd](https://github.com/ledgerwatch/interfaces/commit/b3566cdd9c2e61adb507f6d9e9cd3d06dd8d3445) -> `testinprod-io/erigon-interfaces` [f370bfb](https://github.com/testinprod-io/erigon-interfaces/commit/f370bfb8f01b32f64f75dd92ed0b654e63c73845)