### PR TITLE
Upstream sync - v2.45.3

### DIFF
--- a/execution/execution.proto
+++ b/execution/execution.proto
@@ -49,7 +49,8 @@ message Header {
   types.H256 transaction_hash = 16;
   optional types.H256 base_fee_per_gas = 17;
   optional types.H256 withdrawal_hash = 18;
-  optional types.H256 excess_data_gas = 19;
+  optional uint64 data_gas_used = 19;
+  optional uint64 excess_data_gas = 20;
 }
 
 // Body is a block body for execution

--- a/types/types.proto
+++ b/types/types.proto
@@ -75,7 +75,8 @@ message ExecutionPayload {
   H256 block_hash = 14;
   repeated bytes transactions = 15;
   repeated Withdrawal withdrawals = 16;
-  optional H256 excess_data_gas = 17;
+  optional uint64 data_gas_used = 17;
+  optional uint64 excess_data_gas = 18;
 }
 
 message Withdrawal {


### PR DESCRIPTION
## Upstream sync PR

### erigon
`ledgerwatch/erigon` [v2.45.3](https://github.com/ledgerwatch/erigon/releases/tag/v2.45.3) -> `testinprod-io/op-erigon` [57f5025](https://github.com/testinprod-io/op-erigon/commit/57f5025c9)

### erigon-lib
`ledgerwatch/erigon-lib` [42c9c28](https://github.com/ledgerwatch/erigon-lib/commit/42c9c28) -> `testinprod-io/erigon-lib` [ab32bd8](https://github.com/testinprod-io/erigon-lib/commit/ab32bd8d)

### erigon-interfaces
`ledgerwatch/interfaces` [cdc6e21](https://github.com/ledgerwatch/interfaces/commit/cdc6e215fb3e) -> `testinprod-io/erigon-interfaces` [410b1ba](https://github.com/testinprod-io/erigon-interfaces/commit/410b1ba)