### PR TITLE
[Ecotone] Extend AssembledBlockData

### DIFF
--- a/execution/execution.proto
+++ b/execution/execution.proto
@@ -144,6 +144,7 @@ message AssembledBlockData {
     types.ExecutionPayload execution_payload = 1;
     types.H256 block_value = 2;
     types.BlobsBundleV1 blobs_bundle = 3;
+    types.H256 parent_beacon_block_root = 4;
 }
 
 message GetAssembledBlockResponse {

--- a/execution/execution.proto
+++ b/execution/execution.proto
@@ -144,7 +144,7 @@ message AssembledBlockData {
     types.ExecutionPayload execution_payload = 1;
     types.H256 block_value = 2;
     types.BlobsBundleV1 blobs_bundle = 3;
-    types.H256 parent_beacon_block_root = 4;
+    optional types.H256 parent_beacon_block_root = 4;
 }
 
 message GetAssembledBlockResponse {


### PR DESCRIPTION
For Ecotone HF, we have to add `ParentBeaconBlockRoot` field to `GetPayloadResponse` in op-erigon.
This PR add `ParentBeaconBlockRoot` into `AssembledBlockData` to extend `GetPayloadResponse`.