### PR TITLE
Upstream v2.59.3

### DIFF
--- a/execution/execution.proto
+++ b/execution/execution.proto
@@ -175,6 +175,10 @@ message FrozenBlocksResponse {
     uint64 frozen_blocks = 1;
 }
 
+message HasBlockResponse {
+    bool has_block = 1;
+}
+
 service Execution {
     // Chain Putters.
     rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
@@ -190,6 +194,7 @@ service Execution {
     rpc GetTD(GetSegmentRequest) returns(GetTDResponse);
     rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);
     rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
+    rpc HasBlock(GetSegmentRequest) returns(HasBlockResponse);
     // Ranges
     rpc GetBodiesByRange(GetBodiesByRangeRequest) returns(GetBodiesBatchResponse);
     rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);

--- a/p2psentinel/sentinel.proto
+++ b/p2psentinel/sentinel.proto
@@ -35,6 +35,7 @@ message GossipData {
     bytes data = 1; // SSZ encoded data
     string name = 2;
     optional Peer peer = 3;
+    optional uint64 subnet_id = 4;
 }
 
 message Status {


### PR DESCRIPTION
upstream erigon's interfaces version was pinned into https://github.com/testinprod-io/erigon-interfaces/commit/da5438eaf7a4. To follow that, I have cherry-picked the commit that we need.